### PR TITLE
retry/reconnect on connection failure

### DIFF
--- a/src/webdav4/fsspec.py
+++ b/src/webdav4/fsspec.py
@@ -372,13 +372,22 @@ class WebdavFile(AbstractBufferedFile):
         """Not essential. Creating stub to make pylint happy."""
         raise NotImplementedError
 
+    def seek(self, loc: int, whence: int = 0) -> int:
+        """Set current file location."""
+        super().seek(loc, whence=whence)
+        return self.reader.seek(loc, whence=whence)
+
+    def isatty(self) -> bool:
+        """Check if it is an interactive fileobj."""
+        return False
+
     def close(self) -> None:
         """Close stream."""
         if self.closed:
             return
 
-        self.closed = True
         self.reader.close()
+        self.closed = True
 
     def __reduce_ex__(
         self, protocol: int

--- a/src/webdav4/http.py
+++ b/src/webdav4/http.py
@@ -5,9 +5,13 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 if TYPE_CHECKING:
-    from .types import HTTPResponse, URLTypes
+    from .types import URLTypes
 
 HTTPStatusError = httpx.HTTPStatusError
+HTTPNetworkError = httpx.NetworkError
+HTTPTimeoutException = httpx.TimeoutException
+HTTPResponse = httpx.Response
+HTTPRequest = httpx.Request
 
 
 class Method:

--- a/src/webdav4/stream.py
+++ b/src/webdav4/stream.py
@@ -47,7 +47,7 @@ def request(
     return response
 
 
-@contextmanager
+@contextmanager  # noqa: C901
 def iter_url(  # noqa: C901
     client: "Client",
     url: "URLTypes",

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,9 +1,14 @@
 """Testing stream utilities."""
 
-from io import BytesIO, StringIO
+from io import DEFAULT_BUFFER_SIZE, BytesIO, StringIO
+from typing import Any, Iterator
 
 import pytest
+from pytest import MonkeyPatch
 
+from tests.utils import TmpDir
+from webdav4.client import Client
+from webdav4.fsspec import WebdavFileSystem
 from webdav4.stream import read_until
 
 
@@ -37,3 +42,162 @@ def test_read_until_not_found_any_match():
     buff = StringIO(d)
 
     assert list(read_until(buff, "\n")) == [d]
+
+
+def test_retry_reconnect_on_failure(
+    storage_dir: TmpDir,
+    fs: WebdavFileSystem,
+    client: Client,
+    monkeypatch: MonkeyPatch,
+):
+    """Test retry/reconnect on network failures."""
+    from io import DEFAULT_BUFFER_SIZE
+    from unittest import mock
+
+    from webdav4.http import HTTPNetworkError, HTTPResponse
+
+    original_iter_content = HTTPResponse.iter_bytes
+
+    def bad_iter_content(
+        response: "HTTPResponse", *args: Any, **kwargs: Any
+    ) -> Iterator[bytes]:
+        """Simulate bad connection."""
+        it = original_iter_content(response, *args, **kwargs)
+        for i, chunk in enumerate(it):
+            # Drop connection error on second chunk if there is one
+            if i > 0:
+                raise HTTPNetworkError(
+                    "Simulated connection drop", request=response.request
+                )
+            yield chunk
+
+    # Text should be longer than default chunk to test resume,
+    # using twice of that plus something tests second resume,
+    # this is important because second response is different
+    text1 = "0123456789" * (DEFAULT_BUFFER_SIZE // 10 + 1)
+    storage_dir.gen("sample.txt", text1 * 2)
+    propfind_resp = client.propfind("sample.txt")
+
+    monkeypatch.setattr(HTTPResponse, "iter_bytes", bad_iter_content)
+
+    with mock.patch.object(client, "propfind", return_value=propfind_resp):
+        with client.open("sample.txt") as fd:
+            # Test various .read() variants
+            assert fd.read(len(text1)) == text1
+            assert fd.read() == text1
+            assert fd.read() == ""
+
+        with client.open("sample.txt", mode="rb") as fd:
+            # Test various .read() variants
+            assert fd.read(len(text1)) == text1.encode()
+            assert fd.read() == text1.encode()
+            assert fd.read() == b""
+
+        with fs.open("sample.txt", mode="r") as fd:
+            # Test various .read() variants
+            assert fd.read(len(text1)) == text1
+            assert fd.read() == text1
+            assert fd.read() == ""
+
+        with fs.open("sample.txt") as fd:
+            # Test various .read() variants
+            assert fd.read(len(text1)) == text1.encode()
+            assert fd.read() == text1.encode()
+            assert fd.read() == b""
+
+        # when we cannot detect support for ranges, we should just raise error
+        client.detected_features.supports_ranges = False
+        with client.open("sample.txt", mode="rb") as fd:
+            fd._response.headers.clear()  # type: ignore
+            with pytest.raises(HTTPNetworkError):
+                fd.read()
+
+        with fs.open("sample.txt", mode="rb") as fd:
+            fd.reader._response.headers.clear()  # type: ignore
+            with pytest.raises(HTTPNetworkError):
+                fd.read()
+
+
+def test_open(storage_dir: TmpDir, fs: WebdavFileSystem):
+    """Test opening a remote file from webdav using fs in text mode."""
+    text1 = "0123456789" * (DEFAULT_BUFFER_SIZE // 10 + 1)
+    storage_dir.gen("sample.txt", text1 * 2)
+
+    with fs.open("sample.txt", mode="r") as f:
+        assert not f.closed
+        assert not f.isatty()
+        assert f.readable()
+        assert not f.writable()
+        assert f.seekable()
+        assert f.tell() == 0
+        assert f.read(len(text1)) == text1
+        assert f.tell() == len(text1)
+        assert f.seek(10) == 10
+        assert f.read(len(text1) - 10) == text1[10:]
+        assert f.tell() == len(text1)
+        assert f.seek(len(text1) * 2) == len(text1) * 2
+        assert f.read() == ""
+        assert f.seek(0) == 0
+    assert f.closed
+    f.close()
+
+    text2 = "0123456789\n"
+    storage_dir.gen("sample2.txt", text2 * 10)
+
+    with fs.open("sample2.txt", mode="r") as f:
+        assert f.readline() == text2
+        assert f.readlines() == [text2] * 9
+    assert f.closed
+    f.close()
+
+
+def test_open_binary(storage_dir: TmpDir, fs: WebdavFileSystem):
+    """Test file object in binary mode with fs."""
+    text1 = b"0123456789" * (DEFAULT_BUFFER_SIZE // 10 + 1)
+    storage_dir.gen("sample.txt", text1 * 2)
+    with fs.open("sample.txt", mode="rb") as f:
+        assert not f.closed
+        assert not f.isatty()
+        assert f.readable()
+        assert not f.writable()
+        assert f.seekable()
+        assert f.tell() == 0
+
+        assert f.read(len(text1)) == text1
+        assert f.tell() == len(text1)
+
+        assert f.seek(10) == 10
+        assert f.read(len(text1) - 10) == text1[10:]
+        assert f.tell() == len(text1)
+
+        assert f.seek(len(text1), 1) == len(text1) * 2
+        assert f.read() == b""
+        assert f.seek(-len(text1), 1) == len(text1)
+
+        assert f.seek(0) == 0
+        buff = bytearray(5)
+        assert f.readinto(buff) == 5
+        assert bytes(buff) == text1[:5]
+        length = f.readinto1(buff)
+        assert bytes(buff) == text1[5 : 5 + length]
+        assert f.seek(-10, 2) == f.tell() == len(text1) * 2 - 10
+        assert f.read() == text1[-10:]
+    assert f.closed
+    f.close()
+
+    with fs.open("sample.txt", mode="rb") as f:
+        with pytest.raises(ValueError):
+            f.seek(-10)
+        with pytest.raises(ValueError):
+            f.seek(10, 3)
+    assert f.closed
+    f.close()
+
+    text2 = b"0123456789\n"
+    storage_dir.gen("sample2.txt", text2 * 10)
+
+    with fs.open("sample2.txt", mode="rb") as f:
+        assert f.readline() == text2
+        assert f.readlines() == [text2] * 9
+    assert f.closed
+    f.close()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,7 @@ class TmpDir(PathClass):  # type: ignore
         return cast(str, self.read_text())
 
     def gen(
-        self, struct: Union[str, Dict[str, Any]], text: str = ""
+        self, struct: Union[str, Dict[str, Any]], text: Union[str, bytes] = ""
     ) -> Iterable[str]:
         """Creates folder structure locally from the provided structure.
 


### PR DESCRIPTION
We do this on the basis of feature detection. We try to send
a OPTIONS request to the base URL and see if it advertises
'Accept-Ranges' header. Otherwise, we just use the header from
the opened network request.

This is done in this way because
ownCloud/Nextcloud does not advertise Accept-Ranges header on
GET requests.