### PR TITLE
client: implement callback protocols

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ packages=find:
 python_requires= >=3.6
 
 [options.extras_require]
-fsspec = fsspec==2021.6.1
+fsspec = fsspec==2021.7.0
 all =
     %(fsspec)s
 docs =


### PR DESCRIPTION
This implements support for the callbacks in the underlying client, so that when `put_file()` is used it will pass the `callback` within it's `**kwargs` and it will just work like normal. I wasn't sure about deprecation policy, so supporting for both of the callback options required a bit of typing magic (`casts`), hopefully it is OK. 