### PR TITLE
client: handle propfind response from Nginx dav ext

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ tests =
     typing_extensions==3.10.0.2
     pytest==6.2.5
     pytest-cov==2.12.1
+    respx==0.17.1
     cheroot==8.5.2
     WsgiDAV==3.1.1
     colorama==0.4.4

--- a/tests/test_multistatus.py
+++ b/tests/test_multistatus.py
@@ -71,6 +71,9 @@ def test_dav_properties_empty(args: Tuple[Element]):
     assert props.display_name is None
     assert props.collection is None
     assert props.resource_type is None
+    assert props.status_code is None
+    assert props.reason_phrase is None
+    assert props.status_ok()
 
 
 def test_dav_properties():
@@ -88,6 +91,7 @@ def test_dav_properties():
           <d:getetag>"8db748065bfed5c0731e9c7ee5f9bf4c"</d:getetag>
           <d:getcontenttype>text/plain</d:getcontenttype>
         </d:prop>
+        <d:status>HTTP/1.1 200 OK</d:status>
       </d:propstat>
     </d:response>"""
     elem = fromstring(content)
@@ -116,6 +120,8 @@ def test_dav_properties():
     assert props.display_name == "foo"
     assert props.collection is False
     assert props.resource_type == "file"
+    assert props.status_code == 200
+    assert props.reason_phrase == "OK"
 
     assert props.as_dict() == {
         "created": datetime(2020, 1, 2, 3, 4, 5, tzinfo=tzutc()),
@@ -127,6 +133,7 @@ def test_dav_properties():
         "display_name": "foo",
         "type": "file",
     }
+    assert props.status_ok()
 
 
 def test_dav_properties_partial():
@@ -165,6 +172,10 @@ def test_dav_properties_partial():
     assert props.display_name == "foo"
     assert props.collection is True
     assert props.resource_type == "directory"
+
+    assert props.status_code is None
+    assert props.reason_phrase is None
+    assert props.status_ok()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
It sends a 207 MULTISTATUS response and contains a 404 inside
propstat:status instead of just returning a 404 status code.

It's a bit tricky to use propstat:status for webdav4, as they may
be status for properties, not the resource, and might impact other
webdav servers like Owncloud/Nextcloud, as they return multiple
propstats.

For now, the change only affects propfind users. Also fixed
`isfile` and `isdir` to not raise ResourceNotFound error, and
instead just return False.