### PR TITLE
relax httpx version requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
          language_version: python3
          additional_dependencies:
            - .[dev]
-           - httpx==0.20.0  # for some reasons, httpx is not getting installed
+           - httpx>=0.20.0,<1.0.0  # for some reasons, httpx is not getting installed
            - typing_extensions
            - types-python-dateutil
            - types-pkg_resources

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 [options]
 setup_requires = setuptools_scm>=6.3.1
 install_requires=
-    httpx==0.21.3
+    httpx>=0.20.0,<1.0.0
     python-dateutil>=2.8.1
 package_dir=
     =src
@@ -33,7 +33,7 @@ python_requires= >=3.6
 
 [options.extras_require]
 fsspec = fsspec>=2021.7.0
-http2 = httpx[http2]==0.21.3
+http2 = httpx[http2]>=0.20.0,<1.0.0
 all =
     %(fsspec)s
     %(http2)s


### PR DESCRIPTION
Solves #87 

Unpin httpx version and set it to >=0.20.0,<1.0.0 so it could be included in other projects more easily. 
Not sure if it's correct to unpin it for http2 extra and mypy pre-commit hook too.

pytest completes successfully with both httpx versions, 0.20.0 and 0.21.3