### PR TITLE
adds trailing slash for ls

### DIFF
--- a/src/webdav4/client.py
+++ b/src/webdav4/client.py
@@ -300,7 +300,11 @@ class Client:
         )
 
     def propfind(
-        self, path: str, data: str = None, headers: "HeaderTypes" = None
+        self, 
+        path: str, 
+        data: str = None, 
+        headers: "HeaderTypes" = None, 
+        add_trailing_slash: bool = False,
     ) -> "MultiStatusResponse":
         """Returns properties of the specific resource by propfind request."""
         call = wrap_fn(
@@ -309,6 +313,7 @@ class Client:
             path,
             content=data,
             headers=headers,
+            add_trailing_slash=add_trailing_slash,
         )
         http_resp = self.with_retry(call)
         return parse_multistatus_response(http_resp)
@@ -502,7 +507,11 @@ class Client:
                 (non-collection), ls will return the file entry/details.
                 Otherwise, it will raise an error.
         """
-        result = self.propfind(path, headers={"Depth": "1"})
+        result = self.propfind(
+            path, 
+            headers={"Depth": "1"}, 
+            add_trailing_slash=True,
+        )
         responses = result.responses
 
         url = self.join_url(path)


### PR DESCRIPTION
I am using a Hetzner StorageBox as WebDAV server which uses an Apache httpd under the hood. This server implementation requires trailing slashes for listing directories. Otherwise, it will redirect with a 301, which [is spec conformant](http://www.webdav.org/specs/rfc4918.html#collection.resources). Because `follow_redirects` is `False` this leads to an error.
This PR adds trailing slashes for `ls`.