### PR TITLE
Fix method naming

### DIFF
--- a/src/webdav4/multistatus.py
+++ b/src/webdav4/multistatus.py
@@ -7,7 +7,7 @@ from xml.etree.ElementTree import fromstring as str2xml
 from xml.etree.ElementTree import tostring as xml2string
 
 from .date_utils import from_rfc1123, fromisoformat
-from .urls import URL, join_url_path, relative_url_to, strip_leading_slash
+from .urls import URL, join_url_path, relative_url_to, strip_trailing_slash
 
 if TYPE_CHECKING:
     from httpx import Response as HTTPResponse
@@ -138,7 +138,7 @@ class Response:
         # path_norm is the path-absolute without differentiating
         # `/` at the end. Used as a key for the responses.
         # but does have a slash in front.
-        self.path_norm = strip_leading_slash(self.path)
+        self.path_norm = strip_trailing_slash(self.path)
 
         status_line = prop(response_xml, "status")
         code = None

--- a/src/webdav4/urls.py
+++ b/src/webdav4/urls.py
@@ -4,15 +4,15 @@ from re import sub
 from httpx import URL
 
 
-def strip_leading_slash(path: str) -> str:
+def strip_trailing_slash(path: str) -> str:
     """Strips leading slash from the path, except when it's a root."""
     return path.rstrip("/") if path and path != "/" else path
 
 
 def normalize_path(path: str) -> str:
-    """Normalizes path, removes leading slash."""
+    """Normalizes path, removes trailing slash."""
     path = sub("/{2,}", "/", path)
-    return strip_leading_slash(path)
+    return strip_trailing_slash(path)
 
 
 def join_url(
@@ -28,7 +28,7 @@ def join_url(
 
 def join_url_path(hostname: str, path: str) -> str:
     """Returns path absolute."""
-    path = path.strip("/")
+    path = path.lstrip("/")
     return normalize_path(f"/{hostname}/{path}")
 
 

--- a/src/webdav4/urls.py
+++ b/src/webdav4/urls.py
@@ -5,7 +5,7 @@ from httpx import URL
 
 
 def strip_trailing_slash(path: str) -> str:
-    """Strips leading slash from the path, except when it's a root."""
+    """Strips trailing slash from the path, except when it's a root."""
     return path.rstrip("/") if path and path != "/" else path
 
 
@@ -28,7 +28,7 @@ def join_url(
 
 def join_url_path(hostname: str, path: str) -> str:
     """Returns path absolute."""
-    path = path.lstrip("/")
+    path = path.strip("/")
     return normalize_path(f"/{hostname}/{path}")
 
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -8,7 +8,7 @@ from webdav4.urls import (
     join_url_path,
     normalize_path,
     relative_url_to,
-    strip_leading_slash,
+    strip_trailing_slash,
 )
 
 
@@ -144,4 +144,4 @@ def test_normalize_url(path: str, expected: str):
 )
 def test_strip_leading_slash(path: str, expected: str):
     """Test that it strips leading slash, except the "/" only urls."""
-    assert strip_leading_slash(path) == expected
+    assert strip_trailing_slash(path) == expected


### PR DESCRIPTION
This PR fixes a minor naming mixup where the method removing trailing slashes was called "remove leading slashes".