### PR TITLE
Add header parameter to upload

### DIFF
--- a/src/webdav4/client.py
+++ b/src/webdav4/client.py
@@ -625,6 +625,7 @@ class Client:
         overwrite: bool = False,
         chunk_size: Optional[int] = None,
         callback: Optional[Callable[[int], Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
     ) -> None:
         """Upload file from local path to a given remote path."""
         with open(from_path, mode="rb") as fobj:
@@ -634,6 +635,7 @@ class Client:
                 overwrite=overwrite,
                 chunk_size=chunk_size,
                 callback=callback,
+                headers=headers,
             )
 
     def upload_fileobj(  # noqa: PLR0913
@@ -644,8 +646,12 @@ class Client:
         callback: Optional[Callable[[int], Any]] = None,
         chunk_size: Optional[int] = None,
         size: Optional[int] = None,
+        headers: Optional[Dict[str, str]] = None,
     ) -> None:
         """Upload file from file object to given path."""
+        if headers is None:
+            headers = {}
+
         # we try to avoid chunked transfer as much as possible
         # so we try to use size as a hint if provided.
         # else, we will try to find that out from the file object
@@ -654,7 +660,9 @@ class Client:
         if size is None:
             size = peek_filelike_length(file_obj)
 
-        headers = {"Content-Length": str(size)} if size is not None else None
+        if size is not None:
+            headers = {"Content-Length": str(size), **headers}
+
         if not overwrite and self.exists(to_path):
             raise ResourceAlreadyExists(to_path)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -687,7 +687,7 @@ def test_upload_fobj_size_hints(client: Client):
 
         wrapped = ReadWrapper(BytesIO(b"foobar"))  # type: ignore
         client.upload_fileobj(wrapped, "foobar")  # type: ignore
-        assert m.call_args[1]["headers"] is None
+        assert m.call_args[1]["headers"] == {}
 
         wrapped = ReadWrapper(BytesIO(b"foobar"))  # type: ignore
         client.upload_fileobj(wrapped, "foobar", size=6)  # type: ignore


### PR DESCRIPTION
Adds http header parameter to `Client.upload` and `Client.upload_fileobj`. Allows for setting creation/modified date for nextcloud/owncloud uploads. Solution is inspired by discussion in issue #9.