### PR TITLE
Added support for retrying in `Client.open()`

### DIFF
--- a/src/webdav4/client.py
+++ b/src/webdav4/client.py
@@ -608,11 +608,13 @@ class Client:
             raise IsACollectionError(path, "Cannot open a collection")
         assert mode in {"r", "rt", "rb"}
 
-        with IterStream(
+        call = partial(
+            IterStream,
             self,
             self.join_url(path),
             chunk_size=chunk_size or self.chunk_size,
-        ) as buffer:
+        )
+        with self.with_retry(call) as buffer:
             buff = cast("BinaryIO", buffer)
 
             if mode == "rb":


### PR DESCRIPTION
This is a pull request for issue #207.

Client has a `retry` argument, which is applied in serval methods, but not including `Client.open()`. Although the opened stream is auto recovered from network errors inside `iter_url()`, any error raised from first-time construction is not handled. Maybe handling such errors via the existing retry mechanism is a good idea?