### PR TITLE
Avoid unnecessary reconnections in `IterStream.seek()`

### DIFF
--- a/src/webdav4/stream.py
+++ b/src/webdav4/stream.py
@@ -179,6 +179,13 @@ class IterStream(RawIOBase):
         if loc and not self.supports_ranges:
             raise ValueError("server does not support ranges")
 
+        # If the target position is within the current buffer,
+        # just adjust the buffer and loc without closing the connection.
+        if self._loc <= loc < self._loc + len(self.buffer):
+            self.buffer = self.buffer[loc - self._loc:]
+            self.loc = loc
+            return loc
+
         self.close()
         self._cm = iter_url(self.client, self.url, pos=loc, chunk_size=self.chunk_size)
         _, self._iterator = self._cm.__enter__()


### PR DESCRIPTION
This is the solution of issue https://github.com/skshetry/webdav4/issues/222.

I made small changes to `IterStream.seek()` so that it can reuse the existing connection and buffer as long as the seeking target is within the current buffer. It not only avoids the problem of excessive network traffic, but also reduces the number of HTTP requests. It should be improve performance in most cases.